### PR TITLE
server specific MNAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ update: $(OBJECTS)
 %.done: %.sql
 	@echo "*** $< ***"
 	@csum=$$(md5sum $< | sed 's/ .*//') ; \
-	  cat $< | docker exec -i $$PG_CONTAINER psql -U $$PGUSER -d $$PGDATABASE -vcsum=$$csum -vACME_DOMAIN=$(ACME_DOMAIN) > $@
+	  cat $< | docker exec -i $$PG_CONTAINER psql -U $$PGUSER -d $$PGDATABASE -vcsum=$$csum -vACME_DOMAIN=$(ACME_DOMAIN) -vNSERVER=$(NSERVER) > $@
 
 ## Load updated zone files via psql connection
 update-direct: $(CFG) $(OBJECTSDIRECT)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ PGPASSWORD   ?=
 #- ACME zone suffix
 ACME_DOMAIN  ?=
 
+#- This NS for use in SOA
+NSERVER      ?= 
+
 # ------------------------------------------------------------------------------
 
 all: help

--- a/domain.sql.sample
+++ b/domain.sql.sample
@@ -2,17 +2,19 @@
   Complete PowerDNS zone records
 */
 
+SET vars.ns TO :'NSERVER';
+
 DO $_$
 DECLARE
-  v_domain    text := 'dev.lan';          -- domain name
-  v_ip        text := '127.0.0.1';        -- base ip
-  v_ip1       text := '127.0.1.1';        -- some another ip
-  v_ns        text := 'ns.dev.lan';       -- master DNS host
-  v_ns_admin  text := 'admin.ns.dev.lan'; -- master DNS admin email
-  v_domain_id integer;                    -- internal domain id
-  v_stamp     text;                       -- zone SOA timestamp
-  v_stamp_old text;                       -- previous zone SOA timestamp
-  v_soa       text;                       -- zone SOA
+  v_domain    text := 'dev.lan';                    -- domain name
+  v_ip        text := '127.0.0.1';                  -- base ip
+  v_ip1       text := '127.0.1.1';                  -- some another ip
+  v_ns        text := current_setting('vars.ns');   -- master DNS host
+  v_ns_admin  text := 'admin.ns.dev.lan';           -- master DNS admin email
+  v_domain_id integer;                              -- internal domain id
+  v_stamp     text;                                 -- zone SOA timestamp
+  v_stamp_old text;                                 -- previous zone SOA timestamp
+  v_soa       text;                                 -- zone SOA
 
   v_refresh   int  :=  10800;
   v_retry     int  :=   3600;


### PR DESCRIPTION
Согласно https://datatracker.ietf.org/doc/html/rfc1035#section-3.3.13, MNAME, это мастер-сервер для зоны (откуда все secondary будут делать axfr). Особо рукастые "переводчики" переводят это как "сервер, где лежат все остальные записи..."

Так как наша схема не предполагает выделение какого-либо сервера как мастера, соответственно в SOA каждого неплохо указывать в MNAME самого себя.